### PR TITLE
feat: Add `ocspCertificate` option for response verification

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,10 @@ export type OCSPStatusConfig = {
      */
     ocspUrl?: string;
     /**
+     * The OCSP responder certificate to validate the signature of the OCSP response. If not provided issuer certificate will be used.
+     */
+    ocspCertificate?: string | Buffer | X509Certificate | pkijs.Certificate;
+    /**
      * Whether to validate the signature of the OCSP response. This is enabled by default and should only be disabled for debugging purposes.
      * @defaultValue true
      */

--- a/src/ocsp.ts
+++ b/src/ocsp.ts
@@ -2,6 +2,7 @@ import { webcrypto } from 'node:crypto';
 import { Constructed, Enumerated, GeneralizedTime, OctetString, UTCTime } from 'asn1js';
 import * as pkijs from 'pkijs';
 import type { OCSPStatusConfig, OCSPStatusResponse } from './index';
+import { convertToPkijsCert } from './convert';
 
 const cryptoEngine = new pkijs.CryptoEngine({
     crypto: webcrypto as Crypto,
@@ -214,7 +215,9 @@ async function verifySignature(
         throw new Error('No pkijs crypto engine');
     }
 
-    if (basicOcspResponse.tbsResponseData.responderID instanceof pkijs.RelativeDistinguishedNames) {
+    if (config.ocspCertificate) {
+        signatureCert = convertToPkijsCert(config.ocspCertificate)
+    } else if (basicOcspResponse.tbsResponseData.responderID instanceof pkijs.RelativeDistinguishedNames) {
         if (trustedCert.subject.isEqual(basicOcspResponse.tbsResponseData.responderID)) {
             signatureCert = trustedCert;
         }

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -98,9 +98,30 @@ describe('Error handling', () => {
         });
     });
 
-    test('Aboirt download issuer cert', async () => {
+    test('Abort download issuer cert', async () => {
         await rejects(downloadIssuerCert(leCert, 0), {
             message: 'This operation was aborted',
+        });
+    });
+
+    test('Invalid ocsp certificate format', async () => {
+        await rejects(getCertStatus(leCert, {
+            ca: leIntermediateCA,
+            ocspCertificate: 'invalid-certificate-format',
+        }), {
+            message: /certificate/i,
+        });
+    });
+
+    test('ocspCertificate parameter is passed correctly', async () => {
+        // Just test that the parameter is accepted without throwing immediate parsing errors
+        // This test uses an expired certificate, so we expect "already expired" error,
+        // but the important thing is that ocspCertificate is processed correctly
+        await rejects(getCertStatus(leStagingExpired, {
+            ca: leIntermediateCA,
+            ocspCertificate: leRealRootCA,
+        }), {
+            message: 'The certificate is already expired',
         });
     });
 });


### PR DESCRIPTION
### What is the purpose of this change?

This Pull Request introduces a new optional argument, `ocspCertificate`, to the `OCSPStatusConfig`. This allows developers to provide a specific certificate to be used for verifying the signature of the OCSP response.

Currently, the library implicitly uses the `issuer` certificate to verify the OCSP response. This works well for simple cases where the CA signs OCSP responses directly with its own certificate.

However, in many production PKI setups, the CA delegates this function to a separate, dedicated "OCSP Signing" certificate. This certificate is issued by the CA but is not the CA certificate itself. In such scenarios, the OCSP response signature cannot be verified directly with the original issuer's certificate, causing the verification to fail.

This change provides a way to handle this common and important use case by allowing a custom verification certificate to be supplied.

### How does this solve the problem?

The new `ocspCertificate` option is passed down to the underlying verification logic.

* If `ocspCertificate` is provided, it will be used as the trusted certificate(s) for verifying the OCSP response signature.
* If it is not provided, the library maintains its current behavior and falls back to using the `issuer` certificate for verification.

This makes the change non-breaking and fully backward compatible.

### How to use the new feature

A developer can now pass the `ocspCertificate` in the `request` config.

**Example Usage:**

```javascript
import { getCertStatusByDomain } from 'easy-ocsp';

const ocspSignerCert = fs.readFileSync('./certs/ocsp-signer.cert.pem');

try {
    const ocspResult = await getCertStatusByDomain('example.com', {
       ocspCertificate: ocspSignerCert
    });
    // ...
} catch (e) {
    // Handle errors ...
}
```

### Other relevant information

This enhancement increases the library's flexibility and makes it usable in more complex, production-grade PKI environments.