### PR TITLE
feat: Export core logic for OCSP stapling & update tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,19 +18,13 @@
         "format": "biome format --write",
         "build": "tsup",
         "build:docs": "typedoc --skipErrorChecking",
-        "check:types": "tsc --noEmit",
-        "prepare": "npm run build"
+        "check:types": "tsc --noEmit"
     },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/timokoessler/easy-ocsp.git"
     },
-    "keywords": [
-        "ocsp",
-        "ocsp client",
-        "X.509",
-        "certificate"
-    ],
+    "keywords": ["ocsp", "ocsp client", "X.509", "certificate"],
     "engines": {
         "node": ">=18"
     },

--- a/package.json
+++ b/package.json
@@ -18,13 +18,19 @@
         "format": "biome format --write",
         "build": "tsup",
         "build:docs": "typedoc --skipErrorChecking",
-        "check:types": "tsc --noEmit"
+        "check:types": "tsc --noEmit",
+        "prepare": "npm run build"
     },
     "repository": {
         "type": "git",
         "url": "git+https://github.com/timokoessler/easy-ocsp.git"
     },
-    "keywords": ["ocsp", "ocsp client", "X.509", "certificate"],
+    "keywords": [
+        "ocsp",
+        "ocsp client",
+        "X.509",
+        "certificate"
+    ],
     "engines": {
         "node": ">=18"
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,4 +256,4 @@ export function getCertURLs(cert: string | Buffer | X509Certificate | pkijs.Cert
     return getCAInfoUrls(convertToPkijsCert(cert));
 }
 
-export { downloadCert, parseOCSPResponse };
+export { downloadCert, parseOCSPResponse, convertToPkijsCert };

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,4 +256,4 @@ export function getCertURLs(cert: string | Buffer | X509Certificate | pkijs.Cert
     return getCAInfoUrls(convertToPkijsCert(cert));
 }
 
-export { downloadCert };
+export { downloadCert, parseOCSPResponse };

--- a/test/domains.test.ts
+++ b/test/domains.test.ts
@@ -3,10 +3,8 @@ import { equal } from 'node:assert';
 import { downloadCert, getCertStatus, getCertStatusByDomain } from '../src/index';
 
 const domains = [
-    'timokoessler.de',
     'github.com',
     'www.google.de',
-    'stackoverflow.com',
     'www.microsoft.com',
     'www.apple.com',
     'www.amazon.de',
@@ -19,7 +17,6 @@ const domains = [
     'www.godaddy.com',
     'www.rapidssl.com',
     'www.entrust.com',
-    'https://tkoessler.de',
 ];
 
 describe('Get certificate status by domain', () => {


### PR DESCRIPTION
Hey there!

First off, a huge thank you for creating and maintaining this awesome library 👍
I've made a couple of changes that I hope will make it even more flexible and keep the tests running smoothly.

**Exporting Core Logic for OCSP Stapling**

I've exported the `parseOCSPResponse` and certificate conversion functions. This allows developers to use the library's validation engine without needing to perform a live OCSP request. The main goal is to easily verify OCSP responses that are already available, which is perfect for handling OCSP stapling with Node.js's `tls.TLSSocket`.

Here’s a quick example of how it can be used:

```typescript
// Assuming 'socket' is an established TLSSocket
socket.once('OCSPResponse', async (response: Buffer) => {
  // ...
  const status = await parseOCSPResponse(
      response,
      leafCertPki,
      issuerCertPki,
      {
          // Nonce can't be used in stapling due to response caching
          enableNonce: false
      },
      null,
  );
  // ...
});
```

**Test Suite Updates**

I also did a bit of housekeeping on the tests:

*   **Let's Encrypt Domains**: I removed the domains using Let's Encrypt certificates from the test suite. As you may know, Let's Encrypt is phasing out their OCSP support ([you can read their announcement here](https://letsencrypt.org/2024/12/05/ending-ocsp/)), and their newer certificates no longer include the `ocspUrl`, which was causing the tests to fail.

*   **Expired Test Certificates**: Just a quick heads-up, I noticed that the test certificates for tkoessler.de seem to have expired. When you get a chance to refresh them, it might be a great idea to set their expiration date far, far into the future. That way, we won't have to worry about them expiring again 😅

Thanks again for all your work on this. Let me know what you think!